### PR TITLE
Full text search on services

### DIFF
--- a/psql/functions/main.sql
+++ b/psql/functions/main.sql
@@ -1,0 +1,2 @@
+\ir search_terms_to_tsquery.sql
+\ir search_services.sql

--- a/psql/functions/search_services.sql
+++ b/psql/functions/search_services.sql
@@ -1,0 +1,15 @@
+-- Note that although we reference the search_terms_to_tsquery function twice
+-- here, PostgreSQL will notice it's IMMUTABLE and will (probably) memoize the
+-- first call.
+
+CREATE FUNCTION search_services(search_terms text) RETURNS SETOF services AS $$
+  SELECT
+    *
+  FROM
+    services
+  WHERE
+    services.tsvector @@ app_hidden.search_terms_to_tsquery('simple', search_terms)
+  ORDER BY
+    ts_rank(services.tsvector, app_hidden.search_terms_to_tsquery('simple', search_terms)) DESC,
+    services.uuid DESC;
+$$ LANGUAGE sql STABLE;

--- a/psql/functions/search_terms_to_tsquery.sql
+++ b/psql/functions/search_terms_to_tsquery.sql
@@ -1,0 +1,26 @@
+CREATE FUNCTION app_hidden.search_terms_to_tsquery(config regconfig, search_terms text) RETURNS tsquery AS $$
+DECLARE
+  v_sanitised text;
+  v_sanitised_and_trimmed text;
+  v_joined_with_ampersands text;
+BEGIN
+  v_sanitised = lower(regexp_replace(
+    search_terms,
+    '[^\d\w\s]',
+    ' ',
+    'g'
+  ));
+  v_sanitised_and_trimmed = regexp_replace(
+    v_sanitised,
+    '(^[^\d\w]*|[^\d\w]*$)',
+    '',
+    'g'
+  );
+  v_joined_with_ampersands = regexp_replace(v_sanitised_and_trimmed, '\s+', ' & ', 'g');
+  RETURN to_tsquery(config, v_joined_with_ampersands || ':*');
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+
+COMMENT ON FUNCTION app_hidden.search_terms_to_tsquery(config regconfig, search_terms text) IS
+  E'Converts a web search term to a tsquery that can be used for FTS. This is a poor approximation for websearch_to_tsquery that''s coming in PG11. The final term is treated as a prefix search, all other terms are full matches.';

--- a/psql/main.sql
+++ b/psql/main.sql
@@ -3,10 +3,12 @@ CREATE EXTENSION "uuid-ossp" WITH SCHEMA public;
 CREATE EXTENSION "citext" WITH SCHEMA public;
 
 CREATE SCHEMA app_public;
+CREATE SCHEMA app_hidden;
 CREATE SCHEMA app_private;
 SET search_path to app_public, app_private, public;
 
 CREATE TABLE app_private.version (
+  id                  serial PRIMARY KEY,
   version             text CHECK (version ~ '^\d+\.\d+\.\d+$') primary key
 );
 INSERT INTO app_private.version values ('0.0.1');

--- a/psql/reset_and_seed.sql
+++ b/psql/reset_and_seed.sql
@@ -1,0 +1,17 @@
+-- Erase everything from existing DB
+DROP SCHEMA IF EXISTS app_public CASCADE;
+DROP SCHEMA IF EXISTS app_hidden CASCADE;
+DROP SCHEMA IF EXISTS app_private CASCADE;
+DROP SCHEMA IF EXISTS app_jobs CASCADE;
+DROP EXTENSION IF EXISTS "pgcrypto";
+DROP EXTENSION IF EXISTS "uuid-ossp";
+DROP EXTENSION IF EXISTS "citext";
+
+-- Import the schema again
+\ir main.sql
+
+-- Load some sample data
+\ir seed.sql
+
+-- Load some sample data
+\ir test.sql

--- a/psql/seed.sql
+++ b/psql/seed.sql
@@ -1,0 +1,10 @@
+DO $$
+DECLARE
+  v_user1_uuid uuid = '08BDE84B-757C-4EF9-BF9F-08B2366FF6F1';
+  v_repo1_uuid uuid = 'F034F9D0-B36A-4AE4-858D-564265FA69C3';
+BEGIN
+  INSERT INTO owners (uuid, service_id, username, name) values (v_user1_uuid, '23598043290', 'user1', 'User One');
+  INSERT INTO repos (uuid, owner_uuid, service_id) values (v_repo1_uuid, v_user1_uuid, '92385348957239');
+  INSERT INTO services (repo_uuid, alias, topics) values (v_repo1_uuid, 'repo1', ARRAY['topic', 'database', 'repo', 'microservices']::citext[]);
+END;
+$$ LANGUAGE plpgsql;

--- a/psql/tables/apps.sql
+++ b/psql/tables/apps.sql
@@ -17,3 +17,5 @@ CREATE TABLE app_dns(
 COMMENT on table app_dns is 'Apps may have many DNS endpoints that resolve to the application.';
 COMMENT on column app_dns.hostname is 'A full hostname entry such as foobar.asyncyapp.com, example.com or *.everything.com';
 COMMENT on column app_dns.is_validated is 'If dns resolves properly from registry.';
+
+CREATE INDEX app_dns_app_uuid_fk on app_dns (app_uuid);

--- a/psql/test.sql
+++ b/psql/test.sql
@@ -1,0 +1,38 @@
+SELECT '';
+SELECT '';
+
+SELECT 'Search for "microservices":';
+SELECT * FROM search_services('microservices');
+-- Assert
+SELECT 1/count(*) FROM search_services('microservices');
+SELECT '';
+SELECT '';
+
+SELECT 'Search for "microse":';
+SELECT * FROM search_services('microse');
+-- Assert
+SELECT 1/count(*) FROM search_services('microse');
+SELECT '';
+SELECT '';
+
+SELECT 'Search for "database microse":';
+SELECT * FROM search_services('database microse');
+-- Assert
+SELECT 1/count(*) FROM search_services('database microse');
+SELECT '(should be a row above this)';
+SELECT '';
+SELECT '';
+
+SELECT 'Search for "bananas":';
+SELECT * FROM search_services('bananas');
+-- Assert
+SELECT 1/(case when count(*) = 0 then 1 else 0 end) FROM search_services('bananas');
+SELECT '';
+SELECT '';
+
+SELECT 'Search for "database bana":';
+SELECT * FROM search_services('database bana');
+-- Assert
+SELECT 1/(case when count(*) = 0 then 1 else 0 end) FROM search_services('database bana');
+SELECT '';
+SELECT '';

--- a/reset_and_seed.sh
+++ b/reset_and_seed.sh
@@ -1,0 +1,1 @@
+psql asyncy -1AXtv ON_ERROR_STOP=1 -f psql/reset_and_seed.sql

--- a/scripts/install/postgres.sh
+++ b/scripts/install/postgres.sh
@@ -11,7 +11,7 @@ done
 
 cli_args="-h ${POSTGRES_HOST:-postgres} -U ${POSTGRES_USER:-postgres} -p ${POSTGRES_PORT:-5432} -v ON_ERROR_STOP=1"
 
-res=$(psql $cli_args -Atc "select version from app_private.version;" || echo '')
+res=$(psql $cli_args -Atc "SELECT version FROM app_public.version ORDER BY id DESC LIMIT 1;" || echo '')
 
 if [ "$res" = "" ]; then
   echo '===> Setting up PostgreSQL'


### PR DESCRIPTION
- Adds `tsvector` column to services to enable full text search (FTS) to execute highly efficiently
- Adds `search_services` function for searching for services that match particular search terms, ordering them by the rank of the match (will be more powerful later!)
- Adds a `app_hidden.search_terms_to_tsquery` function which converts a search string into something PostgreSQL's FTS engine understands. This should be replaced by websearch_to_tsquery as soon as PG11 is released!
- Adds a simple reset_and_test script that's useful for development - feel free to drop this commit!

Also I noticed in scripts/install/postgres.sh you're using `POSTGRES_USER` and similar envvars; it might be better to use the standard PostgreSQL envvars [detailed here](https://www.postgresql.org/docs/10/static/libpq-envars.html) - that way you won't need to specify them in the script. (Alternatively, you might consider using PostgreSQL connection strings `postgres://user:pass@host/db_name?ssl_mode=require`)
