### PR TITLE
Add pg notify for new releases

### DIFF
--- a/psql/tables/releases.sql
+++ b/psql/tables/releases.sql
@@ -59,3 +59,14 @@ $$ language plpgsql security definer SET search_path FROM CURRENT;
 
 CREATE TRIGGER _101_releases_defaults before insert on releases
   for each row execute procedure releases_defaults();
+  
+CREATE FUNCTION releases_notify() returns trigger as $$
+  begin
+    -- publish new releases to the channel "release"
+    NOTIFY release, new.app_uuid;
+    return null;
+  end;
+$$ language plpgsql security definer SET search_path FROM CURRENT;
+
+CREATE TRIGGER _900_releases_notify after insert on releases
+  for each row execute procedure releases_notify();


### PR DESCRIPTION
https://www.postgresql.org/docs/9.6/static/sql-notify.html

Using Postgres internal pub/sub the Engine can subscribe to the channel `release` and get notifications of new application releases.

Example pubsub integration in PG https://github.com/stevepeak/tornpsql/blob/master/tornpsql/__init__.py#L32-L66