### PR TITLE
Change service title to name

### DIFF
--- a/psql/tables/organizations.sql
+++ b/psql/tables/organizations.sql
@@ -1,10 +1,13 @@
 CREATE TABLE organizations(
   uuid                    uuid default uuid_generate_v4() primary key,
   owner_uuid              uuid not null default current_owner_uuid(),
-  name                    title not null
+  name                    title not null,
+  username                alias not null
 );
 COMMENT on table organizations is 'An organization is a collection of many teams, apps and repositories.';
 COMMENT on column organizations.owner_uuid is 'The owner of the Organization.';
+COMMENT on column organizations.name is 'The organization name for visual purposes.';
+COMMENT on column organizations.username is 'The organization username for navigation and internal purposes.';
 
 
 CREATE INDEX ON organizations (owner_uuid);

--- a/psql/tables/services.sql
+++ b/psql/tables/services.sql
@@ -34,7 +34,7 @@ CREATE TABLE services(
   repo_uuid                  uuid references repos on delete cascade not null,
   organization_uuid          uuid references organizations on delete cascade,
   owner_uuid                 uuid references owners on delete cascade,
-  title                      title not null,
+  name                       alias not null,
   category                   uuid references service_categories on delete set null,
   description                text,
   alias                      alias unique,
@@ -48,7 +48,8 @@ CREATE TABLE services(
     (organization_uuid IS NULL) <> (owner_uuid IS NULL)
   )
 );
-COMMENT on column services.alias is 'The namespace reservation for the container';
+COMMENT on column services.name is 'The namespace used for the project slug (org/service).';
+COMMENT on column services.alias is 'The namespace reservation for the service';
 COMMENT on column services.category is 'The category this service belongs too.';
 COMMENT on column services.pull_url is 'Address where the container can be pulled from.';
 COMMENT on column services.topics is 'GitHub repository topics for searching services.';
@@ -57,6 +58,7 @@ COMMENT on column services.tsvector is E'@omit\nThis field will not be exposed t
 COMMENT on column services.public is 'If the service is publicly available';
 
 CREATE UNIQUE INDEX services_repo_uuid_fk on services (repo_uuid);
+CREATE UNIQUE INDEX services_names on services (organization_uuid, name);
 CREATE INDEX services_tsvector_idx ON services USING GIN (tsvector);
 CREATE INDEX services_organization_uuid_fk on services (organization_uuid);
 CREATE INDEX services_owners_uuid_fk on services (owner_uuid);

--- a/psql/test.sql
+++ b/psql/test.sql
@@ -41,8 +41,8 @@ SELECT '';
 
 insert into owners(uuid, service, service_id, username) values ('EB0C25D8-5B5A-43F6-81B4-1A3880243C96', 'github', '123', 'U_1');
 insert into owners(uuid, service, service_id, username) values ('B54DC244-DCA4-411A-A439-BC496F9B4256', 'github', '987', 'U_2');
-insert into organizations(uuid, owner_uuid, name) values ('20B199EA-5F50-41D8-8D03-C126A3E8F19C', 'EB0C25D8-5B5A-43F6-81B4-1A3880243C96', 'A');
-insert into organizations(uuid, owner_uuid, name) values ('D74A3C75-FFF9-43E0-BBAB-EB3F76168E6D', 'B54DC244-DCA4-411A-A439-BC496F9B4256', 'B');
+insert into organizations(uuid, owner_uuid, name, username) values ('20B199EA-5F50-41D8-8D03-C126A3E8F19C', 'EB0C25D8-5B5A-43F6-81B4-1A3880243C96', 'A', 'a');
+insert into organizations(uuid, owner_uuid, name, username) values ('D74A3C75-FFF9-43E0-BBAB-EB3F76168E6D', 'B54DC244-DCA4-411A-A439-BC496F9B4256', 'B', 'b');
 insert into repos(uuid, owner_uuid, service, service_id, name) values ('2E2586E2-D2D7-4E6F-B10E-62C89CC47D51', 'EB0C25D8-5B5A-43F6-81B4-1A3880243C96', 'github', '999', 'A-a');
 insert into apps(uuid, organization_uuid, repo_uuid, name, timestamp) values ('E9E97287-3AAC-44DF-A5E0-67AA42F00429', '20B199EA-5F50-41D8-8D03-C126A3E8F19C', '2E2586E2-D2D7-4E6F-B10E-62C89CC47D51', 'A-a-1', now());
 insert into releases(app_uuid, message, owner_uuid, timestamp, payload) values ('E9E97287-3AAC-44DF-A5E0-67AA42F00429', 'Blah 1', 'EB0C25D8-5B5A-43F6-81B4-1A3880243C96', now(), jsonb_build_object());


### PR DESCRIPTION
This name is used in mapping `org/service` is unique per organization.

To fix the [Hub queries](
https://github.com/asyncy/hub/tree/f10aa9b0eecb703301bf167d6907808582277545/src/plugins/graphql/queries). E.g., 

```graphql
{
  recentlyAddedServices: searchServices(searchTerms: "microservice", first: 10) {
    nodes {
      uuid
      alias
      description
      topics
      name
      organization{
        username
      }
    }
  }
}
```